### PR TITLE
Try "pkg update -f"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # illumos-splitroot-scripts
 My article on "Split-root installation" of illumos-based OSes resulted
 in some code better maintained in Git than in Wiki attachments. See:
-http://wiki.openindiana.org/oi/Advanced+-+Split-root+installation
+http://wiki.openindiana.org/oi/Advanced+-+Split-root+installation or
+https://github.com/jimklimov/illumos-articles/raw/master/articles/Advanced%20-%20Split-root%20installation%20-%20OpenIndiana%20Wiki.mht
+for a backup copy (as MHT archive, most browsers read that).
 
-The SMF method scripts and manifests (and/or patches thereto to cater
+The SMF method scripts and manifests (and/or patches thereto, to cater
 for the posterity) presented here allow to add support for "split-root"
 ZFS root filesystem structure, where the OS image is spread over several
 datasets under a common root (which are automatically cloned with the

--- a/README.md
+++ b/README.md
@@ -41,5 +41,113 @@ archive is available.
 
 The script is likely to evolve, keep tuned...
 
+Note that beside piggy-backing on ISO releases, there is also a published
+recipe at https://github.com/alhazred/firefly which you could use to
+maintain your own failsafe archive in a more "correct" manner (e.g. build
+yours after updating your system).
+
+See also the original Firefly blog post at
+https://alexeremin.blogspot.com/2013/05/firefly-failsafe-image-for-illumos.html
+
+### Installing a Firefly ISO release as a rootfs
+
+The condensed procedure to create a template `firefly_MMYY` rootfs for
+automated use with these scripts follows:
+
+1) Fetch current firefly build (e.g. 0516 as of now) from SourceForge:
+https://sourceforge.net/projects/fireflyfailsafe/files/latest/download
+
+I clicked in browser to get into "Problems Downloading?" and got a
+direct link for `wget`:
+
+````
+:; ISOURL='https://downloads.sourceforge.net/project/fireflyfailsafe/firefly_05052016.iso?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Ffireflyfailsafe%2Ffiles%2Ffirefly_05052016.iso%2Fdownload&ts=1555172974'
+:; mkdir -p /export/distribs/firefly-failsafe && \
+   cd /export/distribs/firefly-failsafe/ && \
+   wget -O firefly_05052016.iso "$ISOURL"
+````
+
+2) Make and populate empty new rootfs (uncompressed so any old kernel
+likes it):
+
+````
+:; zfs create -o mountpoint=/ -o compression=off -o canmount=noauto \
+      -o org.opensolaris.libbe:uuid=1d2111c8-f169-43d7-e758-f7d8e4ff0516 \
+      rpool/ROOT/firefly_0516
+
+:; beadm mount firefly_0516 /a
+:; LOFI_FFISO="`lofiadm -a /export/distribs/firefly-failsafe/firefly_05052016.iso`"
+:; mount -F hsfs -o ro "$LOFI_FFISO" /mnt/cdrom
+
+:; rsync -avPHK /mnt/cdrom/ /a/
+:; touch /a/reconfigure
+
+:; umount /mnt/cdrom
+:; lofiadm -d "$LOFI_FFISO"
+
+:; zfs snapshot rpool/ROOT/firefly_0516@firefly-05052016-original
+````
+
+3) One more bit of experience: the procedure referenced above, to maintain
+a failsafe archive for my system as I upgrade its OS over time, had
+recently hit a wall with the archive running out of space so the
+copied-over current kernel did not fit.
+
+Extend the "firefly" boot archive, with 128M here on top of its original
+~150M (no big deal, used as a compressed template anyway; however take care
+to balance it against the tmpfs storage overhead during upgrades on your
+system):
+
+````
+:; gzcat /a/platform/i86pc/amd64/firefly > /tmp/fff
+:; dd if=/dev/zero bs=4096 count=32768 >> /tmp/fff
+:; LOFI_FFUFS="`lofiadm -a /tmp/fff`"
+:; RLOFI_FFUFS="`echo "$LOFI_FFUFS" | sed 's,/lofi/,/rlofi/,'`"
+
+:; growfs "$RLOFI_FFUFS"
+/dev/rlofi/1:   1386000 sectors in 2310 cylinders of 1 tracks, 600 sectors
+        676.8MB in 145 cyl groups (16 c/g, 4.69MB/g, 2240 i/g)
+super-block backups (for fsck -F ufs -o b=#) at:
+ 32, 9632, 19232, 28832, 38432, 48032, 57632, 67232, 76832, 86432,
+ 1296032, 1305632, 1315232, 1324832, 1334432, 1344032, 1353632, 1363232,
+ 1372832, 1382432
+````
+
+3a) Can check the space reports:
+
+````
+:; mount -F ufs -o rw "$LOFI_FFUFS" /mnt/cdrom
+:; df -k /mnt/cdrom ; umount "$LOFI_FFUFS"
+
+Filesystem     1K-blocks   Used Available Use% Mounted on
+/dev/lofi/1       650061 148447    501614  23% /mnt/cdrom
+````
+
+3b) Let go of the LOFI device:
+
+````
+:; lofiadm -d "$LOFI_FFUFS"
+````
+
+3c) Get the template back into place... tagging the timestamp back to
+see when the downloaded content originated:
+
+````
+:; touch -r /a/platform/i86pc/amd64/firefly /tmp/fff
+:; gzip -9 -c < /tmp/fff > /a/platform/i86pc/amd64/firefly
+:; touch -r /tmp/fff /a/platform/i86pc/amd64/firefly
+:; zfs snapshot rpool/ROOT/firefly_0516@firefly-05052016-expanded
+````
+
+4) Whether or not you expanded the UFS image, tidy up by unmounting
+the new rootfs:
+````
+:; beadm umount /a
+````
+
+When you next utter `./beadm-update.sh` or `./beadm-firefly-update.sh`,
+your system should use a failsafe enviromnent based on this template
+rootfs, if things go south.
+
 Hope this helps,
 Jim Klimov

--- a/bin/beadm-upgrade.sh
+++ b/bin/beadm-upgrade.sh
@@ -281,12 +281,20 @@ do_upgrade_pkgips() {
         { echo "===== Refreshing IPS package list"
           /usr/bin/pkg -R "$BENEW_MNT" refresh
           RES_PKGIPS=$?; [ "$RES_PKGIPS" = 0 ] ; } && \
-        { echo "===== Updating PKG software itself"
-          ### This clause should fail if no 'pkg' updates were available, or if a
-          ### chrooted upgrade attempt with the new 'pkg' failed - both ways fall
-          ### through to altroot upgrade attempt
-          /usr/bin/pkg -R "$BENEW_MNT" update --no-refresh --accept --deny-new-be --no-backup-be pkg
-          RES_PKGIPS=$?; [ "$RES_PKGIPS" = 0 ] || [ "$RES_PKGIPS" = 4 ] ; } && \
+        { { echo "===== Updating both PKG and the BE clone with an older client from original BE ==="
+            ### Newer "pkg" clients support a "-f" option to skip the
+            ### client-up-to-date check while updating packages; this
+            ### is expected to "update" most if not all of the software.
+            ### Just in case, we would follow up by "image-update" below.
+            /usr/bin/pkg -R "$BENEW_MNT" update --no-refresh --accept --deny-new-be --no-backup-be -f
+            RES_PKGIPS=$?; [ "$RES_PKGIPS" = 0 ] || [ "$RES_PKGIPS" = 4 ] ; } || \
+          { echo "===== Updating PKG software itself as a separate step ==="
+            ### This clause should fail if no 'pkg' updates were available, or if a
+            ### chrooted upgrade attempt with the new 'pkg' failed - both ways fall
+            ### through to altroot upgrade attempt
+            /usr/bin/pkg -R "$BENEW_MNT" update --no-refresh --accept --deny-new-be --no-backup-be pkg
+            RES_PKGIPS=$?; [ "$RES_PKGIPS" = 0 ] || [ "$RES_PKGIPS" = 4 ] ; }
+        } && \
         { echo "===== Updating the image with new PKG software via chroot with a special variable"
           PKG_LIVE_ROOT=/// chroot "$BENEW_MNT" /usr/bin/pkg -R / image-update --no-refresh --accept --deny-new-be --no-backup-be
           RES_PKGIPS=$?; [ "$RES_PKGIPS" = 0 ] || [ "$RES_PKGIPS" = 4 ] ; } || \

--- a/bin/beadm-upgrade.sh
+++ b/bin/beadm-upgrade.sh
@@ -383,7 +383,7 @@ do_reconfig() {
 
 do_firefly() {
     [ -x "`dirname "$0"`/beadm-firefly-update.sh" ] && \
-    if [ $RES_PKGIPS -le 0 -a $RES_PKGSRC -le 0 -a $RES_BOOTADM -le 0 ] || \
+    if ( [ $RES_PKGIPS -le 0 -o $RES_PKGIPS = 4 ] && [ $RES_PKGSRC -le 0 -a $RES_BOOTADM -le 0 ] ) || \
        [ -n "`set | egrep '^FIREFLY_[A-Za-z0-9_]*='`" ] \
     ; then
         [ -z "$FIREFLY_CONTAINER_TGT" ] && \

--- a/bin/beadm-upgrade.sh
+++ b/bin/beadm-upgrade.sh
@@ -304,7 +304,13 @@ do_upgrade_pkgips() {
         { echo "===== Updating the image with new PKG software via chroot"
           chroot "$BENEW_MNT" /usr/bin/pkg -R / image-update --no-refresh --accept --deny-new-be --no-backup-be
           RES_PKGIPS=$?; [ "$RES_PKGIPS" = 0 ] || [ "$RES_PKGIPS" = 4 ] ; } || \
+        { echo "===== Updating the image with old PKG software via altroot and ignoring the pkg client version constraints"
+          /usr/bin/pkg -R "$BENEW_MNT" image-update --no-refresh --accept --deny-new-be --no-backup-be -f
+          RES_PKGIPS=$?; [ "$RES_PKGIPS" = 0 ] || [ "$RES_PKGIPS" = 4 ] ; } || \
         { echo "===== Updating the image with old PKG software via altroot and allowed refresh"
+          /usr/bin/pkg -R "$BENEW_MNT" image-update --accept --deny-new-be --no-backup-be
+          RES_PKGIPS=$?; [ "$RES_PKGIPS" = 0 ] || [ "$RES_PKGIPS" = 4 ] ; } || \
+        { echo "===== Updating the image with old PKG software via altroot and allowed refresh and ignoring the pkg client version constraints"
           /usr/bin/pkg -R "$BENEW_MNT" image-update --accept --deny-new-be --no-backup-be
           RES_PKGIPS=$?; }
 


### PR DESCRIPTION
https://pastebin.com/PvHUSLLL

Here I was trying to update an OmniOS bloody system last done in November, and this script which worked okay for years handling update of PKG itself first, and then using it, or the older PKG as a fallback, to update the actual packages, failed spectacularly. 

It seems that due to maybe packaging issue (dependencies of PKG itself), the new PKG required a new libpython which required an updated illumos libc, and the software in the chroot did not provide a consistent set of binaries after installing the updated PKG. As a result, it could not work from chroot (missing symbols) and not from original system (client too old).

Now we'll try to add these options... Thanks to @andyf for the suggestion.